### PR TITLE
Remove tile key from model.eval call

### DIFF
--- a/deeptile/extensions/segmentation.py
+++ b/deeptile/extensions/segmentation.py
@@ -34,7 +34,7 @@ def cellpose_segmentation(model_parameters, eval_parameters, output_format='mask
     def _func_segment(tile, index, tile_index, stitch_index, tiling):
 
         tile = compute_dask(tile)
-        mask = model.eval(tile, tile=False, **eval_parameters)[0]
+        mask = model.eval(tile, **eval_parameters)[0]
 
         if output_format == 'masks':
             return mask

--- a/deeptile/extensions/segmentation.py
+++ b/deeptile/extensions/segmentation.py
@@ -24,11 +24,11 @@ def cellpose_segmentation(model_parameters, eval_parameters, output_format='mask
         Lifted function for the Cellpose segmentation algorithm.
     """
 
-    from cellpose.models import Cellpose
+    from cellpose.models import CellposeModel
     from cellpose.io import logger_setup
     logger_setup()
 
-    model = Cellpose(**model_parameters)
+    model = CellposeModel(**model_parameters)
 
     @lift
     def _func_segment(tile, index, tile_index, stitch_index, tiling):


### PR DESCRIPTION
Tried rebuilding some workers from scratch, got that there was some issue with cellpose. I think cellpose now doesn't take the "tile" keyword parameter, so I just removed it and it seemed to work okay.